### PR TITLE
feat(htmx): implement Stage 2 HTMX integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,29 +9,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Initial project structure
-- Core library with module stubs:
-  - `config` - Configuration loading and validation
-  - `render` - Markdown to HTML rendering
-  - `frontmatter` - YAML frontmatter parsing
-  - `manifest` - Manifest.json generation
-  - `search` - Search index generation
-  - `assets` - Asset hashing with SRI
-  - `templates` - Tera template engine setup
+- HTMX attribute injection module (`render/htmx.rs`)
+  - Injects `hx-boost`, `hx-target`, `hx-swap` on `<body>`
+  - Generates navigation link attributes
+  - Preload hints for hover prefetching
+- Out-of-Band (OOB) swap generation (`render/oob.rs`)
+  - Sidebar OOB updates with active state
+  - Breadcrumb OOB updates
+  - NavItem and Breadcrumb data structures
+- New templates for HTMX integration
+  - `nav.html` - Main navigation component with HTMX attributes
+  - `partials/sidebar-oob.html` - Sidebar for OOB swaps
+  - `partials/breadcrumb.html` - Breadcrumb navigation trail
+  - `partials/loading.html` - HTMX loading indicator
+- Updated layout template with:
+  - Sidebar navigation panel
+  - Loading spinner indicator
+  - Breadcrumb placeholder
+  - HTMX event handlers for enhanced UX
+  - Mobile responsive design
+- Fragment template now includes:
+  - OOB update placeholder
+  - Lazy loading support
+
+### Changed
+
+- Updated `render/mod.rs` to export HTMX and OOB modules
+- Enhanced `HtmxRenderer.render_chapter()` to:
+  - Build navigation sidebar context
+  - Generate OOB updates for fragments
+  - Pass all chapters for navigation building
+
+## [0.1.0] - 2024-01-04
+
+### Added
+
+- Core library modules:
+  - `config` - Configuration loading from `[output.htmx]`
+  - `context` - RenderContext parsing from stdin JSON
+  - `render` - Markdown to HTML with pulldown-cmark
+  - `frontmatter` - YAML frontmatter parsing and validation
+  - `manifest` - manifest.json generation
+  - `search` - Search index generation (stub)
+  - `assets` - Asset hashing with SRI (SHA-384) and xxHash
+  - `templates` - Tera template engine with custom filters
+- HtmxRenderer with full render pipeline
+- Embedded templates (layout.html, docs/page.html, docs/fragment.html)
+- Full HtmxConfig with navigation, search, and assets options
+- Prev/next chapter navigation
+- GitHub-compatible heading slugification
 - Error types with exit codes per ADR-0017
 - CI/CD workflows for GitHub Actions
 - Dual license (MIT OR Apache-2.0)
-
-## [0.1.0] - Unreleased
-
-### Planned
-
-- Parse RenderContext from stdin
-- Load and validate [output.htmx] configuration
-- Set up Tera template engine with embedded templates
-- Parse frontmatter from chapter files
-- Render pages and fragments
-- Generate manifest.json
 
 [Unreleased]: https://github.com/aRustyDev/mdbook-htmx/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/aRustyDev/mdbook-htmx/releases/tag/v0.1.0

--- a/src/render/htmx.rs
+++ b/src/render/htmx.rs
@@ -1,0 +1,169 @@
+//! HTMX attribute injection.
+//!
+//! Injects HTMX attributes into HTML for SPA-like navigation.
+
+use crate::config::{HtmxConfig, SwapStrategy};
+
+/// Inject HTMX attributes into rendered HTML.
+///
+/// Adds:
+/// - `hx-boost="true"` on `<body>` (if boost enabled)
+/// - `hx-target` and `hx-swap` defaults
+/// - `hx-push-url="true"` on navigation links (if push_url enabled)
+pub fn inject_htmx_attrs(html: &str, config: &HtmxConfig) -> String {
+    let mut html = html.to_string();
+
+    // Add hx-boost to body
+    if config.boost {
+        html = inject_body_attrs(&html, config);
+    }
+
+    // Add hx-push-url to navigation links
+    if config.push_url {
+        html = inject_push_url(&html);
+    }
+
+    html
+}
+
+/// Convert SwapStrategy to its HTMX string representation.
+fn swap_strategy_to_str(strategy: &SwapStrategy) -> &'static str {
+    match strategy {
+        SwapStrategy::InnerHTML => "innerHTML",
+        SwapStrategy::OuterHTML => "outerHTML",
+        SwapStrategy::BeforeBegin => "beforebegin",
+        SwapStrategy::AfterBegin => "afterbegin",
+        SwapStrategy::BeforeEnd => "beforeend",
+        SwapStrategy::AfterEnd => "afterend",
+        SwapStrategy::Delete => "delete",
+        SwapStrategy::None => "none",
+    }
+}
+
+/// Inject HTMX attributes on the `<body>` tag.
+fn inject_body_attrs(html: &str, config: &HtmxConfig) -> String {
+    let swap_str = swap_strategy_to_str(&config.swap_strategy);
+
+    // Find <body and inject attributes
+    if let Some(body_pos) = html.find("<body") {
+        let (before, after) = html.split_at(body_pos);
+        // Find the end of the opening tag
+        if let Some(tag_end) = after.find('>') {
+            let (tag_start, rest) = after.split_at(tag_end);
+            // Check if there are existing attributes
+            let attrs = format!(
+                " hx-boost=\"true\" hx-target=\"{}\" hx-swap=\"{}\"",
+                config.target, swap_str
+            );
+
+            // Insert before the closing >
+            return format!("{}{}{}{}", before, tag_start, attrs, rest);
+        }
+    }
+
+    html.to_string()
+}
+
+/// Inject `hx-push-url="true"` on navigation links.
+///
+/// Targets links with class `nav-link` or within navigation elements.
+fn inject_push_url(html: &str) -> String {
+    // For now, we rely on template-level attributes rather than post-processing.
+    // The templates include hx-push-url on navigation links.
+    // This function is here for future enhancements like link processing.
+    html.to_string()
+}
+
+/// Generate HTMX attributes for a navigation link.
+///
+/// Returns a string of HTMX attributes to add to an `<a>` tag.
+pub fn nav_link_attrs(target: &str, swap: &SwapStrategy, push_url: bool) -> String {
+    let swap_str = swap_strategy_to_str(swap);
+    let swap_with_scroll = format!("{} show:window:top", swap_str);
+
+    let mut attrs = format!(
+        "hx-boost=\"true\" hx-target=\"{}\" hx-swap=\"{}\"",
+        target, swap_with_scroll
+    );
+
+    if push_url {
+        attrs.push_str(" hx-push-url=\"true\"");
+    }
+
+    attrs
+}
+
+/// Generate preload hint for hover prefetching.
+pub fn preload_hint(path: &str) -> String {
+    format!(r#"<link rel="prefetch" href="{}" as="document">"#, path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_inject_body_attrs() {
+        let html = r#"<html><body class="main"><div>Content</div></body></html>"#;
+        let config = HtmxConfig::default();
+
+        let result = inject_htmx_attrs(html, &config);
+
+        assert!(result.contains("hx-boost=\"true\""));
+        assert!(result.contains("hx-target=\"#content\""));
+        assert!(result.contains("hx-swap=\"innerHTML\""));
+    }
+
+    #[test]
+    fn test_inject_body_attrs_custom_target() {
+        let html = r#"<html><body><div>Content</div></body></html>"#;
+        let mut config = HtmxConfig::default();
+        config.target = "#main".to_string();
+        config.swap_strategy = SwapStrategy::OuterHTML;
+
+        let result = inject_htmx_attrs(html, &config);
+
+        assert!(result.contains("hx-target=\"#main\""));
+        assert!(result.contains("hx-swap=\"outerHTML\""));
+    }
+
+    #[test]
+    fn test_no_boost() {
+        let html = r#"<html><body><div>Content</div></body></html>"#;
+        let mut config = HtmxConfig::default();
+        config.boost = false;
+
+        let result = inject_htmx_attrs(html, &config);
+
+        assert!(!result.contains("hx-boost"));
+    }
+
+    #[test]
+    fn test_nav_link_attrs() {
+        let attrs = nav_link_attrs("#content", &SwapStrategy::InnerHTML, true);
+
+        assert!(attrs.contains("hx-boost=\"true\""));
+        assert!(attrs.contains("hx-target=\"#content\""));
+        assert!(attrs.contains("hx-push-url=\"true\""));
+    }
+
+    #[test]
+    fn test_preload_hint() {
+        let hint = preload_hint("/chapter/intro");
+        assert_eq!(
+            hint,
+            r#"<link rel="prefetch" href="/chapter/intro" as="document">"#
+        );
+    }
+
+    #[test]
+    fn test_swap_strategy_strings() {
+        assert_eq!(swap_strategy_to_str(&SwapStrategy::InnerHTML), "innerHTML");
+        assert_eq!(swap_strategy_to_str(&SwapStrategy::OuterHTML), "outerHTML");
+        assert_eq!(
+            swap_strategy_to_str(&SwapStrategy::BeforeBegin),
+            "beforebegin"
+        );
+        assert_eq!(swap_strategy_to_str(&SwapStrategy::AfterEnd), "afterend");
+    }
+}

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,6 +1,15 @@
 //! Rendering logic for mdbook-htmx.
 //!
-//! Handles Markdown to HTML conversion using pulldown-cmark.
+//! Handles Markdown to HTML conversion using pulldown-cmark,
+//! HTMX attribute injection, and OOB swap generation.
+
+pub mod htmx;
+pub mod oob;
+
+pub use htmx::{inject_htmx_attrs, nav_link_attrs, preload_hint};
+pub use oob::{
+    render_oob_updates, Breadcrumb, BreadcrumbContext, NavItem, OobUpdates, SidebarContext,
+};
 
 use pulldown_cmark::{html, Options, Parser};
 

--- a/src/render/oob.rs
+++ b/src/render/oob.rs
@@ -1,0 +1,308 @@
+//! Out-of-Band (OOB) swap generation.
+//!
+//! Generates OOB updates for sidebar and breadcrumbs that are appended
+//! to fragment responses. This enables updating multiple parts of the
+//! page with a single HTMX request.
+
+use serde::Serialize;
+use tera::{Context, Tera};
+
+use crate::context::Chapter;
+
+/// Breadcrumb entry for navigation trail.
+#[derive(Debug, Clone, Serialize)]
+pub struct Breadcrumb {
+    /// Display title
+    pub title: String,
+    /// URL path
+    pub path: String,
+    /// Whether this is the current page
+    pub is_current: bool,
+}
+
+/// Navigation item for sidebar.
+#[derive(Debug, Clone, Serialize)]
+pub struct NavItem {
+    /// Display title
+    pub title: String,
+    /// URL path
+    pub path: String,
+    /// Whether this item is currently active
+    pub is_active: bool,
+    /// Nested items (for collapsible sections)
+    pub children: Vec<NavItem>,
+    /// Whether this section is expanded
+    pub is_expanded: bool,
+    /// Chapter number (e.g., "1.2")
+    pub number: Option<String>,
+}
+
+/// Context for rendering OOB sidebar.
+#[derive(Debug, Clone, Serialize)]
+pub struct SidebarContext {
+    /// Navigation items
+    pub items: Vec<NavItem>,
+    /// Currently active path
+    pub active_path: String,
+}
+
+/// Context for rendering OOB breadcrumb.
+#[derive(Debug, Clone, Serialize)]
+pub struct BreadcrumbContext {
+    /// Breadcrumb trail
+    pub crumbs: Vec<Breadcrumb>,
+}
+
+/// OOB update result containing all generated OOB HTML.
+#[derive(Debug, Clone, Default)]
+pub struct OobUpdates {
+    /// Sidebar OOB HTML
+    pub sidebar: Option<String>,
+    /// Breadcrumb OOB HTML
+    pub breadcrumb: Option<String>,
+}
+
+impl OobUpdates {
+    /// Combine all OOB updates into a single HTML string.
+    pub fn to_html(&self) -> String {
+        let mut html = String::new();
+
+        if let Some(ref sidebar) = self.sidebar {
+            html.push_str(sidebar);
+        }
+
+        if let Some(ref breadcrumb) = self.breadcrumb {
+            html.push_str(breadcrumb);
+        }
+
+        html
+    }
+
+    /// Check if there are any OOB updates.
+    pub fn is_empty(&self) -> bool {
+        self.sidebar.is_none() && self.breadcrumb.is_none()
+    }
+}
+
+/// Render OOB updates for a chapter.
+///
+/// # Arguments
+/// * `tera` - Template engine
+/// * `chapter` - Current chapter being rendered
+/// * `all_chapters` - All chapters for sidebar navigation
+/// * `active_path` - URL path of current page
+///
+/// # Returns
+/// OOB updates to append to fragment response
+pub fn render_oob_updates(
+    tera: &Tera,
+    chapter: &Chapter,
+    all_chapters: &[&Chapter],
+    active_path: &str,
+) -> anyhow::Result<OobUpdates> {
+    let mut updates = OobUpdates::default();
+
+    // Build sidebar context
+    let sidebar_items = build_nav_items(all_chapters, active_path);
+    let sidebar_ctx = SidebarContext {
+        items: sidebar_items,
+        active_path: active_path.to_string(),
+    };
+
+    // Render sidebar OOB
+    let mut ctx = Context::new();
+    ctx.insert("sidebar", &sidebar_ctx);
+    ctx.insert("active_path", &active_path);
+
+    if let Ok(sidebar_html) = tera.render("partials/sidebar-oob.html", &ctx) {
+        updates.sidebar = Some(format!(
+            r#"<nav id="sidebar" hx-swap-oob="true">{}</nav>"#,
+            sidebar_html
+        ));
+    }
+
+    // Build breadcrumb context
+    let crumbs = build_breadcrumbs(chapter, active_path);
+    let breadcrumb_ctx = BreadcrumbContext { crumbs };
+
+    // Render breadcrumb OOB
+    ctx.insert("breadcrumb", &breadcrumb_ctx);
+
+    if let Ok(breadcrumb_html) = tera.render("partials/breadcrumb.html", &ctx) {
+        updates.breadcrumb = Some(format!(
+            r#"<nav id="breadcrumb" aria-label="Breadcrumb" hx-swap-oob="true">{}</nav>"#,
+            breadcrumb_html
+        ));
+    }
+
+    Ok(updates)
+}
+
+/// Build navigation items from chapters.
+fn build_nav_items(chapters: &[&Chapter], active_path: &str) -> Vec<NavItem> {
+    chapters
+        .iter()
+        .filter_map(|ch| {
+            ch.path.as_ref().map(|path| {
+                let url_path = path_to_url(path);
+                let is_active = url_path == active_path;
+                let is_expanded = is_active || active_path.starts_with(&url_path);
+
+                NavItem {
+                    title: ch.name.clone(),
+                    path: url_path,
+                    is_active,
+                    children: vec![], // TODO: Handle nested chapters
+                    is_expanded,
+                    number: ch.number.as_ref().map(|nums| {
+                        nums.iter()
+                            .map(|n| n.to_string())
+                            .collect::<Vec<_>>()
+                            .join(".")
+                    }),
+                }
+            })
+        })
+        .collect()
+}
+
+/// Build breadcrumb trail for a chapter.
+fn build_breadcrumbs(chapter: &Chapter, active_path: &str) -> Vec<Breadcrumb> {
+    let mut crumbs = Vec::new();
+
+    // Home crumb
+    crumbs.push(Breadcrumb {
+        title: "Home".to_string(),
+        path: "/".to_string(),
+        is_current: active_path == "/",
+    });
+
+    // Parent crumbs from parent_names
+    for parent in chapter.parent_names.iter() {
+        // Build path from parent structure
+        // This is simplified - in practice, we'd need to track parent paths
+        crumbs.push(Breadcrumb {
+            title: parent.clone(),
+            path: format!("/{}", parent.to_lowercase().replace(' ', "-")),
+            is_current: false,
+        });
+    }
+
+    // Current page crumb
+    if active_path != "/" {
+        crumbs.push(Breadcrumb {
+            title: chapter.name.clone(),
+            path: active_path.to_string(),
+            is_current: true,
+        });
+    }
+
+    crumbs
+}
+
+/// Convert file path to URL path.
+fn path_to_url(path: &std::path::Path) -> String {
+    let path_str = path.with_extension("").to_string_lossy().to_string();
+
+    if path_str == "README" || path_str.ends_with("/README") {
+        if path_str == "README" {
+            "/".to_string()
+        } else {
+            format!("/{}/", path_str.trim_end_matches("/README"))
+        }
+    } else {
+        format!("/{}", path_str.replace('\\', "/"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_breadcrumb_home() {
+        let chapter = Chapter {
+            name: "Home".to_string(),
+            content: String::new(),
+            path: Some(PathBuf::from("README.md")),
+            source_path: None,
+            number: None,
+            sub_items: vec![],
+            parent_names: vec![],
+        };
+
+        let crumbs = build_breadcrumbs(&chapter, "/");
+        assert_eq!(crumbs.len(), 1);
+        assert!(crumbs[0].is_current);
+    }
+
+    #[test]
+    fn test_breadcrumb_nested() {
+        let chapter = Chapter {
+            name: "Installation".to_string(),
+            content: String::new(),
+            path: Some(PathBuf::from("guide/installation.md")),
+            source_path: None,
+            number: Some(vec![1, 2]),
+            sub_items: vec![],
+            parent_names: vec!["Guide".to_string()],
+        };
+
+        let crumbs = build_breadcrumbs(&chapter, "/guide/installation");
+        assert_eq!(crumbs.len(), 3); // Home > Guide > Installation
+        assert!(!crumbs[0].is_current); // Home
+        assert!(!crumbs[1].is_current); // Guide
+        assert!(crumbs[2].is_current); // Installation
+    }
+
+    #[test]
+    fn test_nav_items() {
+        let ch1 = Chapter {
+            name: "Introduction".to_string(),
+            content: String::new(),
+            path: Some(PathBuf::from("intro.md")),
+            source_path: None,
+            number: Some(vec![1]),
+            sub_items: vec![],
+            parent_names: vec![],
+        };
+
+        let ch2 = Chapter {
+            name: "Guide".to_string(),
+            content: String::new(),
+            path: Some(PathBuf::from("guide.md")),
+            source_path: None,
+            number: Some(vec![2]),
+            sub_items: vec![],
+            parent_names: vec![],
+        };
+
+        let chapters: Vec<&Chapter> = vec![&ch1, &ch2];
+        let items = build_nav_items(&chapters, "/intro");
+
+        assert_eq!(items.len(), 2);
+        assert!(items[0].is_active);
+        assert!(!items[1].is_active);
+        assert_eq!(items[0].number, Some("1".to_string()));
+    }
+
+    #[test]
+    fn test_oob_updates_to_html() {
+        let updates = OobUpdates {
+            sidebar: Some("<ul>sidebar</ul>".to_string()),
+            breadcrumb: Some("<ol>crumbs</ol>".to_string()),
+        };
+
+        let html = updates.to_html();
+        assert!(html.contains("sidebar"));
+        assert!(html.contains("crumbs"));
+    }
+
+    #[test]
+    fn test_oob_updates_empty() {
+        let updates = OobUpdates::default();
+        assert!(updates.is_empty());
+        assert!(updates.to_html().is_empty());
+    }
+}

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -16,6 +16,19 @@ const BUILTIN_TEMPLATES: &[(&str, &str)] = &[
         "docs/fragment.html",
         include_str!("../../templates/docs/fragment.html"),
     ),
+    ("nav.html", include_str!("../../templates/nav.html")),
+    (
+        "partials/sidebar-oob.html",
+        include_str!("../../templates/partials/sidebar-oob.html"),
+    ),
+    (
+        "partials/breadcrumb.html",
+        include_str!("../../templates/partials/breadcrumb.html"),
+    ),
+    (
+        "partials/loading.html",
+        include_str!("../../templates/partials/loading.html"),
+    ),
 ];
 
 /// Initialize the Tera template engine with embedded templates.

--- a/templates/docs/fragment.html
+++ b/templates/docs/fragment.html
@@ -28,4 +28,16 @@
         {% endif %}
     </nav>
     {% endif %}
+
+    {% if page.htmx.lazy | default(value=false) %}
+    <div hx-get="{{ page.path }}/extended"
+         hx-trigger="revealed"
+         hx-swap="outerHTML"
+         class="lazy-content-placeholder">
+        <span class="sr-only">Loading additional content...</span>
+    </div>
+    {% endif %}
 </article>
+
+{# OOB updates for sidebar and breadcrumb #}
+{{ oob_updates | safe }}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -15,6 +15,10 @@
             --link-color: #0066cc;
             --border-color: #e0e0e0;
             --code-bg: #f5f5f5;
+            --sidebar-width: 280px;
+            --sidebar-bg: #f8f9fa;
+            --nav-active-bg: #e9ecef;
+            --nav-hover-bg: #f1f3f5;
         }
         [data-theme="dark"] {
             --bg-color: #1a1a1a;
@@ -22,6 +26,9 @@
             --link-color: #66b3ff;
             --border-color: #404040;
             --code-bg: #2d2d2d;
+            --sidebar-bg: #242424;
+            --nav-active-bg: #3d3d3d;
+            --nav-hover-bg: #333333;
         }
         * { box-sizing: border-box; margin: 0; padding: 0; }
         body {
@@ -29,6 +36,61 @@
             line-height: 1.6;
             background: var(--bg-color);
             color: var(--text-color);
+        }
+        .layout {
+            display: flex;
+            min-height: 100vh;
+        }
+        .sidebar {
+            width: var(--sidebar-width);
+            background: var(--sidebar-bg);
+            border-right: 1px solid var(--border-color);
+            padding: 1rem;
+            position: sticky;
+            top: 0;
+            height: 100vh;
+            overflow-y: auto;
+        }
+        .sidebar-header {
+            padding: 1rem 0;
+            border-bottom: 1px solid var(--border-color);
+            margin-bottom: 1rem;
+        }
+        .sidebar-header a {
+            font-weight: 600;
+            text-decoration: none;
+            color: var(--text-color);
+        }
+        .nav-list {
+            list-style: none;
+        }
+        .nav-item {
+            margin: 0.25rem 0;
+        }
+        .nav-link {
+            display: flex;
+            align-items: center;
+            padding: 0.5rem 0.75rem;
+            color: var(--text-color);
+            text-decoration: none;
+            border-radius: 4px;
+            transition: background-color 0.15s;
+        }
+        .nav-link:hover {
+            background: var(--nav-hover-bg);
+        }
+        .nav-link.active {
+            background: var(--nav-active-bg);
+            font-weight: 500;
+        }
+        .nav-number {
+            margin-right: 0.5rem;
+            color: #888;
+            font-size: 0.875rem;
+        }
+        .main-content {
+            flex: 1;
+            max-width: calc(100% - var(--sidebar-width));
         }
         .container { max-width: 900px; margin: 0 auto; padding: 2rem; }
         main { min-height: 60vh; }
@@ -45,8 +107,87 @@
         .nav-footer a { text-decoration: none; }
         .skip-link { position: absolute; left: -9999px; }
         .skip-link:focus { left: 0; top: 0; background: var(--bg-color); padding: 0.5rem; z-index: 1000; }
-        .htmx-indicator { display: none; }
-        .htmx-request .htmx-indicator { display: inline-block; }
+
+        /* Breadcrumb styles */
+        .breadcrumb-list {
+            display: flex;
+            align-items: center;
+            list-style: none;
+            padding: 0.5rem 0;
+            margin-bottom: 1rem;
+            font-size: 0.875rem;
+        }
+        .breadcrumb-item {
+            display: flex;
+            align-items: center;
+        }
+        .breadcrumb-separator {
+            margin: 0 0.5rem;
+            opacity: 0.5;
+        }
+        .breadcrumb-item.current {
+            color: #888;
+        }
+
+        /* HTMX loading indicator */
+        .htmx-indicator {
+            opacity: 0;
+            position: fixed;
+            top: 1rem;
+            right: 1rem;
+            z-index: 1000;
+            transition: opacity 200ms ease-in;
+        }
+        .htmx-request .htmx-indicator,
+        .htmx-request.htmx-indicator {
+            opacity: 1;
+        }
+        .loading-spinner {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: var(--bg-color);
+            padding: 0.5rem;
+            border-radius: 50%;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+        }
+        .spinner {
+            animation: spin 1s linear infinite;
+        }
+        .spinner-track {
+            stroke: var(--border-color);
+        }
+        .spinner-head {
+            stroke: var(--link-color);
+        }
+        @keyframes spin {
+            from { transform: rotate(0deg); }
+            to { transform: rotate(360deg); }
+        }
+        .sr-only {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
+        }
+
+        /* Mobile responsive */
+        @media (max-width: 768px) {
+            .layout { flex-direction: column; }
+            .sidebar {
+                width: 100%;
+                height: auto;
+                position: relative;
+                border-right: none;
+                border-bottom: 1px solid var(--border-color);
+            }
+            .main-content { max-width: 100%; }
+        }
     </style>
 </head>
 <body
@@ -57,22 +198,69 @@
 >
     <a href="#content" class="skip-link">Skip to main content</a>
 
-    <div class="container">
-        <header>
-            <h1><a href="/">{{ config.book.title | default(value="Documentation") }}</a></h1>
-        </header>
+    <!-- Loading indicator -->
+    <div id="loading-indicator" class="htmx-indicator" aria-live="polite">
+        <div class="loading-spinner" role="status">
+            <svg class="spinner" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                <circle class="spinner-track" cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="2"/>
+                <circle class="spinner-head" cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-dasharray="31.4 31.4" stroke-dashoffset="10"/>
+            </svg>
+            <span class="sr-only">Loading...</span>
+        </div>
+    </div>
 
-        <main id="content" role="main">
-            {% block content %}
-            {{ body | safe }}
-            {% endblock %}
-        </main>
+    <div class="layout">
+        <!-- Sidebar navigation -->
+        <aside class="sidebar" aria-label="Table of contents">
+            <div class="sidebar-header">
+                <a href="/" hx-boost="true" hx-target="#content" hx-push-url="true">
+                    {{ config.book.title | default(value="Documentation") }}
+                </a>
+            </div>
+            <nav id="sidebar" aria-label="Chapters">
+                {% if navigation %}
+                {% include "partials/sidebar-oob.html" ignore missing %}
+                {% endif %}
+            </nav>
+        </aside>
 
-        <footer style="margin-top: 2rem; padding-top: 1rem; border-top: 1px solid var(--border-color); font-size: 0.9rem; color: #666;">
-            <p>Generated by <a href="https://github.com/aRustyDev/mdbook-htmx">mdbook-htmx</a></p>
-        </footer>
+        <!-- Main content area -->
+        <div class="main-content">
+            <div class="container">
+                <!-- Breadcrumb navigation -->
+                <nav id="breadcrumb" aria-label="Breadcrumb">
+                    {% if breadcrumb %}
+                    {% include "partials/breadcrumb.html" ignore missing %}
+                    {% endif %}
+                </nav>
+
+                <main id="content" role="main">
+                    {% block content %}
+                    {{ body | safe }}
+                    {% endblock %}
+                </main>
+
+                <footer style="margin-top: 2rem; padding-top: 1rem; border-top: 1px solid var(--border-color); font-size: 0.9rem; color: #666;">
+                    <p>Generated by <a href="https://github.com/aRustyDev/mdbook-htmx">mdbook-htmx</a></p>
+                </footer>
+            </div>
+        </div>
     </div>
 
     <script src="https://unpkg.com/htmx.org@1.9.10" crossorigin="anonymous"></script>
+    <script>
+        // HTMX event handlers for enhanced UX
+        document.body.addEventListener('htmx:beforeRequest', function(evt) {
+            document.body.classList.add('htmx-request');
+        });
+        document.body.addEventListener('htmx:afterRequest', function(evt) {
+            document.body.classList.remove('htmx-request');
+        });
+
+        // Restore scroll position on back/forward navigation
+        document.body.addEventListener('htmx:historyRestore', function(evt) {
+            window.scrollTo(0, 0);
+        });
+    </script>
 </body>
 </html>

--- a/templates/nav.html
+++ b/templates/nav.html
@@ -1,0 +1,39 @@
+{# templates/nav.html - Main navigation component #}
+<nav class="doc-nav" aria-label="Documentation navigation">
+    <div class="nav-header">
+        <a href="/" class="nav-brand" hx-boost="true" hx-target="#content" hx-push-url="true">
+            {% if config.book.title %}
+            <span class="nav-brand-text">{{ config.book.title }}</span>
+            {% endif %}
+        </a>
+        <button id="nav-toggle" class="nav-menu-toggle" aria-expanded="false" aria-controls="sidebar">
+            <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                <path d="M3 12h18M3 6h18M3 18h18" fill="none" stroke="currentColor" stroke-width="2"/>
+            </svg>
+            <span class="sr-only">Toggle navigation</span>
+        </button>
+    </div>
+
+    <nav id="sidebar" class="sidebar" aria-label="Table of contents">
+        <ul class="nav-list" role="tree">
+            {% for item in navigation.items %}
+            <li class="nav-item {% if item.path == current_path %}active{% endif %}"
+                role="treeitem"
+                aria-selected="{{ item.path == current_path }}">
+                <a href="{{ item.path }}"
+                   class="nav-link {% if item.path == current_path %}active{% endif %}"
+                   hx-boost="true"
+                   hx-target="#content"
+                   hx-swap="innerHTML show:window:top"
+                   hx-push-url="true"
+                   {% if item.path == current_path %}aria-current="page"{% endif %}>
+                    {% if item.number %}
+                    <span class="nav-number">{{ item.number }}</span>
+                    {% endif %}
+                    <span class="nav-title">{{ item.title }}</span>
+                </a>
+            </li>
+            {% endfor %}
+        </ul>
+    </nav>
+</nav>

--- a/templates/partials/breadcrumb.html
+++ b/templates/partials/breadcrumb.html
@@ -1,0 +1,19 @@
+{# templates/partials/breadcrumb.html - Breadcrumb navigation trail #}
+<ol class="breadcrumb-list" aria-label="Breadcrumb">
+    {% for crumb in breadcrumb.crumbs %}
+    <li class="breadcrumb-item {% if crumb.is_current %}current{% endif %}">
+        {% if crumb.is_current %}
+        <span aria-current="page">{{ crumb.title }}</span>
+        {% else %}
+        <a href="{{ crumb.path }}"
+           hx-get="{{ crumb.path }}"
+           hx-target="#content"
+           hx-swap="innerHTML show:window:top"
+           hx-push-url="true">{{ crumb.title }}</a>
+        <svg class="breadcrumb-separator" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+            <path d="M9 18l6-6-6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+        </svg>
+        {% endif %}
+    </li>
+    {% endfor %}
+</ol>

--- a/templates/partials/loading.html
+++ b/templates/partials/loading.html
@@ -1,0 +1,10 @@
+{# templates/partials/loading.html - HTMX loading indicator #}
+<div id="loading-indicator" class="htmx-indicator" aria-live="polite">
+    <div class="loading-spinner" role="status">
+        <svg class="spinner" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+            <circle class="spinner-track" cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="2" opacity="0.25"/>
+            <circle class="spinner-head" cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-dasharray="31.4 31.4" stroke-dashoffset="10"/>
+        </svg>
+        <span class="sr-only">Loading...</span>
+    </div>
+</div>

--- a/templates/partials/sidebar-oob.html
+++ b/templates/partials/sidebar-oob.html
@@ -1,0 +1,50 @@
+{# templates/partials/sidebar-oob.html - Sidebar navigation for OOB swaps #}
+<ul class="nav-list" role="tree">
+    {% for item in sidebar.items %}
+    <li class="nav-item {% if item.is_active %}active{% endif %} {% if item.is_expanded %}expanded{% endif %}"
+        role="treeitem"
+        aria-selected="{{ item.is_active }}">
+        <a href="{{ item.path }}"
+           class="nav-link {% if item.is_active %}active{% endif %}"
+           hx-get="{{ item.path }}"
+           hx-target="#content"
+           hx-swap="innerHTML show:window:top"
+           hx-push-url="true"
+           {% if item.is_active %}aria-current="page"{% endif %}>
+            {% if item.number %}
+            <span class="nav-number">{{ item.number }}</span>
+            {% endif %}
+            <span class="nav-title">{{ item.title }}</span>
+        </a>
+        {% if item.children | length > 0 %}
+        <button class="nav-toggle"
+                aria-expanded="{{ item.is_expanded }}"
+                aria-label="Toggle {{ item.title }} section">
+            <svg class="toggle-icon" viewBox="0 0 24 24" width="16" height="16">
+                <path d="M9 18l6-6-6-6" fill="none" stroke="currentColor" stroke-width="2"/>
+            </svg>
+        </button>
+        <ul class="nav-children" role="group">
+            {% for child in item.children %}
+            <li class="nav-item {% if child.is_active %}active{% endif %}"
+                role="treeitem"
+                aria-selected="{{ child.is_active }}">
+                <a href="{{ child.path }}"
+                   class="nav-link {% if child.is_active %}active{% endif %}"
+                   hx-get="{{ child.path }}"
+                   hx-target="#content"
+                   hx-swap="innerHTML show:window:top"
+                   hx-push-url="true"
+                   {% if child.is_active %}aria-current="page"{% endif %}>
+                    {% if child.number %}
+                    <span class="nav-number">{{ child.number }}</span>
+                    {% endif %}
+                    <span class="nav-title">{{ child.title }}</span>
+                </a>
+            </li>
+            {% endfor %}
+        </ul>
+        {% endif %}
+    </li>
+    {% endfor %}
+</ul>


### PR DESCRIPTION
## Summary

- Implements HTMX attribute injection for SPA-like navigation
- Adds Out-of-Band (OOB) swap generation for sidebar and breadcrumb updates
- Creates new templates for navigation, loading indicators, and OOB updates
- Updates layout with sidebar navigation, loading spinner, and mobile responsive design

## Changes

### New Files
- `src/render/htmx.rs` - HTMX attribute injection
- `src/render/oob.rs` - OOB swap generation
- `templates/nav.html` - Navigation component
- `templates/partials/sidebar-oob.html` - Sidebar for OOB swaps
- `templates/partials/breadcrumb.html` - Breadcrumb navigation
- `templates/partials/loading.html` - Loading indicator

### Modified Files
- `src/lib.rs` - Integrated OOB generation into render pipeline
- `src/render/mod.rs` - Exports new modules
- `src/templates/mod.rs` - Embeds new templates
- `templates/layout.html` - Added sidebar, loading spinner, responsive design
- `templates/docs/fragment.html` - Added OOB placeholder and lazy loading

## Test plan

- [x] All 29 unit tests pass
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt` applied
- [x] `cargo doc` builds without warnings
- [ ] Manual testing with a sample book

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)