### PR TITLE
feat(auth): implement Stage 3 authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Authentication configuration (`config::AuthnConfig`)
+  - Provider types: `none`, `custom`, `oidc`
+  - Configurable signin/signout endpoints
+  - Session cookie name setting
+  - User info endpoint for current user
+- Authorization configuration (`config::AuthzConfig`)
+  - Default access levels: `public`, `authenticated`, `denied`
+  - Default fallback page for access denied
+  - JWT role claim configuration
+  - Strict mode option (deny if role claim missing)
+- Frontmatter auth fields
+  - `authn` - Authentication level (`public`, `authenticated`, `verified`)
+  - `authz` - Required roles list
+  - `fallback` - Custom fallback page for access denied
+- Auth templates
+  - `partials/signin.html` - Sign-in prompt partial
+  - `partials/access-denied.html` - Access denied partial
+  - `401.html` - Unauthorized error page
+  - `403.html` - Forbidden error page
+- `AuthnLevel.as_str()` and `Display` implementation
 - HTMX attribute injection module (`render/htmx.rs`)
   - Injects `hx-boost`, `hx-target`, `hx-swap` on `<body>`
   - Generates navigation link attributes
@@ -22,6 +42,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `partials/sidebar-oob.html` - Sidebar for OOB swaps
   - `partials/breadcrumb.html` - Breadcrumb navigation trail
   - `partials/loading.html` - HTMX loading indicator
+
+### Changed
+
+- `HtmxConfig` now includes `authn` and `authz` configuration
+- Manifest includes auth metadata from frontmatter
+- Updated `render/mod.rs` to export HTMX and OOB modules
+- Enhanced `HtmxRenderer.render_chapter()` to:
+  - Build navigation sidebar context
+  - Generate OOB updates for fragments
+  - Pass all chapters for navigation building
 - Updated layout template with:
   - Sidebar navigation panel
   - Loading spinner indicator
@@ -31,14 +61,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fragment template now includes:
   - OOB update placeholder
   - Lazy loading support
-
-### Changed
-
-- Updated `render/mod.rs` to export HTMX and OOB modules
-- Enhanced `HtmxRenderer.render_chapter()` to:
-  - Build navigation sidebar context
-  - Generate OOB updates for fragments
-  - Pass all chapters for navigation building
 
 ## [0.1.0] - 2024-01-04
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,11 +152,7 @@ impl HtmxRenderer {
                     page_path: PathBuf::from("pages").join(&rendered.path),
                     fragment_path: PathBuf::from("fragments").join(&rendered.path),
                     scope: rendered.frontmatter.scope.clone(),
-                    authn: rendered
-                        .frontmatter
-                        .authn
-                        .as_ref()
-                        .map(|a| format!("{:?}", a).to_lowercase()),
+                    authn: rendered.frontmatter.authn.as_ref().map(|a| a.to_string()),
                     authz: rendered.frontmatter.authz.clone(),
                     fallback: rendered.frontmatter.fallback.clone(),
                     content_hash: assets::compute_short_hash(rendered.page.as_bytes()),

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -29,6 +29,17 @@ const BUILTIN_TEMPLATES: &[(&str, &str)] = &[
         "partials/loading.html",
         include_str!("../../templates/partials/loading.html"),
     ),
+    // Auth templates
+    (
+        "partials/signin.html",
+        include_str!("../../templates/partials/signin.html"),
+    ),
+    (
+        "partials/access-denied.html",
+        include_str!("../../templates/partials/access-denied.html"),
+    ),
+    ("401.html", include_str!("../../templates/401.html")),
+    ("403.html", include_str!("../../templates/403.html")),
 ];
 
 /// Initialize the Tera template engine with embedded templates.
@@ -153,5 +164,18 @@ mod tests {
         assert!(tera.get_template_names().any(|n| n == "layout.html"));
         assert!(tera.get_template_names().any(|n| n == "docs/page.html"));
         assert!(tera.get_template_names().any(|n| n == "docs/fragment.html"));
+    }
+
+    #[test]
+    fn test_auth_templates_loaded() {
+        let tera = init_templates().expect("Failed to initialize templates");
+        assert!(tera
+            .get_template_names()
+            .any(|n| n == "partials/signin.html"));
+        assert!(tera
+            .get_template_names()
+            .any(|n| n == "partials/access-denied.html"));
+        assert!(tera.get_template_names().any(|n| n == "401.html"));
+        assert!(tera.get_template_names().any(|n| n == "403.html"));
     }
 }

--- a/templates/401.html
+++ b/templates/401.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="{{ config.book.language | default(value='en') }}" data-theme="light">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex, nofollow">
+    <title>401 Unauthorized - {{ config.book.title | default(value="Documentation") }}</title>
+    <style>
+        :root {
+            --bg-color: #ffffff;
+            --text-color: #333333;
+            --link-color: #0066cc;
+            --border-color: #e0e0e0;
+            --sidebar-bg: #f8f9fa;
+        }
+        [data-theme="dark"] {
+            --bg-color: #1a1a1a;
+            --text-color: #e0e0e0;
+            --link-color: #66b3ff;
+            --border-color: #404040;
+            --sidebar-bg: #242424;
+        }
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            line-height: 1.6;
+            background: var(--bg-color);
+            color: var(--text-color);
+        }
+        .error-container {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            padding: 2rem;
+            text-align: center;
+        }
+        .error-icon {
+            margin-bottom: 1.5rem;
+            color: #ffc107;
+        }
+        .error-code {
+            font-size: 4rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: var(--text-color);
+            opacity: 0.8;
+        }
+        .error-title {
+            font-size: 1.5rem;
+            margin-bottom: 1rem;
+        }
+        .error-message {
+            color: #666;
+            max-width: 500px;
+            margin-bottom: 2rem;
+        }
+        .error-actions {
+            display: flex;
+            gap: 1rem;
+            flex-wrap: wrap;
+            justify-content: center;
+        }
+        .error-button {
+            display: inline-block;
+            padding: 0.75rem 2rem;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.15s;
+        }
+        .error-button.primary {
+            background: var(--link-color);
+            color: #fff !important;
+        }
+        .error-button.primary:hover {
+            opacity: 0.9;
+        }
+        .error-button.secondary {
+            background: transparent;
+            color: var(--text-color);
+            border: 1px solid var(--border-color);
+        }
+        .error-button.secondary:hover {
+            background: var(--sidebar-bg);
+        }
+        [data-theme="dark"] .error-message {
+            color: #aaa;
+        }
+    </style>
+</head>
+<body>
+    <div class="error-container">
+        <div class="error-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" width="64" height="64" fill="none" stroke="currentColor" stroke-width="1.5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z"/>
+            </svg>
+        </div>
+        <div class="error-code">401</div>
+        <h1 class="error-title">Authentication Required</h1>
+        <p class="error-message">
+            You need to sign in to access this page. Please authenticate to continue.
+        </p>
+        <div class="error-actions">
+            <a href="{{ signin_url | default(value='/auth/login') }}" class="error-button primary">
+                Sign In
+            </a>
+            <a href="/" class="error-button secondary">
+                Return Home
+            </a>
+        </div>
+    </div>
+
+    <script>
+        // Detect system theme preference
+        if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+            document.documentElement.setAttribute('data-theme', 'dark');
+        }
+    </script>
+</body>
+</html>

--- a/templates/403.html
+++ b/templates/403.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="{{ config.book.language | default(value='en') }}" data-theme="light">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex, nofollow">
+    <title>403 Forbidden - {{ config.book.title | default(value="Documentation") }}</title>
+    <style>
+        :root {
+            --bg-color: #ffffff;
+            --text-color: #333333;
+            --link-color: #0066cc;
+            --border-color: #e0e0e0;
+            --sidebar-bg: #f8f9fa;
+        }
+        [data-theme="dark"] {
+            --bg-color: #1a1a1a;
+            --text-color: #e0e0e0;
+            --link-color: #66b3ff;
+            --border-color: #404040;
+            --sidebar-bg: #242424;
+        }
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            line-height: 1.6;
+            background: var(--bg-color);
+            color: var(--text-color);
+        }
+        .error-container {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            padding: 2rem;
+            text-align: center;
+        }
+        .error-icon {
+            margin-bottom: 1.5rem;
+            color: #dc3545;
+        }
+        .error-code {
+            font-size: 4rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: var(--text-color);
+            opacity: 0.8;
+        }
+        .error-title {
+            font-size: 1.5rem;
+            margin-bottom: 1rem;
+            color: #dc3545;
+        }
+        .error-message {
+            color: #666;
+            max-width: 500px;
+            margin-bottom: 1rem;
+        }
+        .error-help {
+            font-size: 0.875rem;
+            color: #888;
+            max-width: 500px;
+            margin-bottom: 2rem;
+        }
+        .error-actions {
+            display: flex;
+            gap: 1rem;
+            flex-wrap: wrap;
+            justify-content: center;
+        }
+        .error-button {
+            display: inline-block;
+            padding: 0.75rem 2rem;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.15s;
+        }
+        .error-button.primary {
+            background: var(--link-color);
+            color: #fff !important;
+        }
+        .error-button.primary:hover {
+            opacity: 0.9;
+        }
+        .error-button.secondary {
+            background: transparent;
+            color: var(--text-color);
+            border: 1px solid var(--border-color);
+        }
+        .error-button.secondary:hover {
+            background: var(--sidebar-bg);
+        }
+        [data-theme="dark"] .error-message,
+        [data-theme="dark"] .error-help {
+            color: #aaa;
+        }
+    </style>
+</head>
+<body>
+    <div class="error-container">
+        <div class="error-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" width="64" height="64" fill="none" stroke="currentColor" stroke-width="1.5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636"/>
+            </svg>
+        </div>
+        <div class="error-code">403</div>
+        <h1 class="error-title">Access Forbidden</h1>
+        <p class="error-message">
+            You don't have permission to access this page.
+        </p>
+        <p class="error-help">
+            If you believe this is an error, please contact the documentation administrator
+            or try signing in with a different account.
+        </p>
+        <div class="error-actions">
+            <a href="/" class="error-button primary">
+                Return Home
+            </a>
+            <a href="{{ signout_url | default(value='/auth/logout') }}" class="error-button secondary">
+                Sign Out
+            </a>
+        </div>
+    </div>
+
+    <script>
+        // Detect system theme preference
+        if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+            document.documentElement.setAttribute('data-theme', 'dark');
+        }
+    </script>
+</body>
+</html>

--- a/templates/partials/access-denied.html
+++ b/templates/partials/access-denied.html
@@ -1,0 +1,114 @@
+{# Access denied partial for pages the user doesn't have permission to view #}
+{# Variables: title, message, required_roles, fallback_url, signin_url, is_authenticated #}
+
+<div class="auth-denied" role="region" aria-labelledby="denied-heading">
+    <div class="denied-card">
+        <div class="denied-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" width="48" height="48" fill="none" stroke="currentColor" stroke-width="1.5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636"/>
+            </svg>
+        </div>
+        <h2 id="denied-heading">{{ title | default(value="Access Denied") }}</h2>
+        <p class="denied-message">
+            {{ message | default(value="You don't have permission to view this content.") }}
+        </p>
+        {% if required_roles %}
+        <p class="denied-roles">
+            Required role{% if required_roles | length > 1 %}s{% endif %}:
+            <span class="role-list">{{ required_roles | join(sep=", ") }}</span>
+        </p>
+        {% endif %}
+        <div class="denied-actions">
+            {% if is_authenticated %}
+            <a href="{{ fallback_url | default(value='/') }}" class="denied-button primary" hx-boost="true">
+                Return Home
+            </a>
+            <a href="{{ signout_url | default(value='/auth/logout') }}" class="denied-button secondary" hx-boost="false">
+                Sign Out
+            </a>
+            {% else %}
+            <a href="{{ signin_url | default(value='/auth/login') }}" class="denied-button primary" hx-boost="false">
+                Sign In
+            </a>
+            <a href="{{ fallback_url | default(value='/') }}" class="denied-button secondary" hx-boost="true">
+                Return Home
+            </a>
+            {% endif %}
+        </div>
+    </div>
+</div>
+
+<style>
+.auth-denied {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 50vh;
+    padding: 2rem;
+}
+.denied-card {
+    text-align: center;
+    padding: 2rem;
+    max-width: 450px;
+    background: var(--sidebar-bg, #f8f9fa);
+    border-radius: 8px;
+    border: 1px solid var(--border-color, #e0e0e0);
+}
+.denied-icon {
+    margin-bottom: 1rem;
+    color: #dc3545;
+}
+.denied-card h2 {
+    margin: 0 0 0.5rem;
+    font-size: 1.5rem;
+    color: #dc3545;
+}
+.denied-message {
+    color: #666;
+    margin-bottom: 1rem;
+}
+.denied-roles {
+    font-size: 0.875rem;
+    color: #888;
+    margin-bottom: 1.5rem;
+}
+.role-list {
+    font-family: monospace;
+    background: var(--code-bg, #f5f5f5);
+    padding: 0.2em 0.4em;
+    border-radius: 3px;
+}
+.denied-actions {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+.denied-button {
+    display: inline-block;
+    padding: 0.75rem 1.5rem;
+    text-decoration: none;
+    border-radius: 4px;
+    font-weight: 500;
+    transition: background-color 0.15s;
+}
+.denied-button.primary {
+    background: var(--link-color, #0066cc);
+    color: #fff !important;
+}
+.denied-button.primary:hover {
+    background: color-mix(in srgb, var(--link-color, #0066cc) 85%, black);
+}
+.denied-button.secondary {
+    background: transparent;
+    color: var(--text-color);
+    border: 1px solid var(--border-color, #e0e0e0);
+}
+.denied-button.secondary:hover {
+    background: var(--nav-hover-bg, #f1f3f5);
+}
+[data-theme="dark"] .denied-message,
+[data-theme="dark"] .denied-roles {
+    color: #aaa;
+}
+</style>

--- a/templates/partials/signin.html
+++ b/templates/partials/signin.html
@@ -1,0 +1,67 @@
+{# Sign-in prompt partial for pages requiring authentication #}
+{# Variables: signin_url, return_url, message #}
+
+<div class="auth-signin" role="region" aria-labelledby="signin-heading">
+    <div class="signin-card">
+        <div class="signin-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" width="48" height="48" fill="none" stroke="currentColor" stroke-width="1.5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15m3 0l3-3m0 0l-3-3m3 3H9"/>
+            </svg>
+        </div>
+        <h2 id="signin-heading">Sign In Required</h2>
+        <p class="signin-message">
+            {{ message | default(value="Please sign in to view this content.") }}
+        </p>
+        <a href="{{ signin_url | default(value='/auth/login') }}{% if return_url %}?return={{ return_url | urlencode }}{% endif %}"
+           class="signin-button"
+           hx-boost="false">
+            Sign In
+        </a>
+    </div>
+</div>
+
+<style>
+.auth-signin {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 50vh;
+    padding: 2rem;
+}
+.signin-card {
+    text-align: center;
+    padding: 2rem;
+    max-width: 400px;
+    background: var(--sidebar-bg, #f8f9fa);
+    border-radius: 8px;
+    border: 1px solid var(--border-color, #e0e0e0);
+}
+.signin-icon {
+    margin-bottom: 1rem;
+    color: var(--link-color, #0066cc);
+}
+.signin-card h2 {
+    margin: 0 0 0.5rem;
+    font-size: 1.5rem;
+}
+.signin-message {
+    color: #666;
+    margin-bottom: 1.5rem;
+}
+.signin-button {
+    display: inline-block;
+    padding: 0.75rem 2rem;
+    background: var(--link-color, #0066cc);
+    color: #fff !important;
+    text-decoration: none;
+    border-radius: 4px;
+    font-weight: 500;
+    transition: background-color 0.15s;
+}
+.signin-button:hover {
+    background: color-mix(in srgb, var(--link-color, #0066cc) 85%, black);
+}
+[data-theme="dark"] .signin-message {
+    color: #aaa;
+}
+</style>


### PR DESCRIPTION
## Summary

Implements authentication and authorization configuration for mdbook-htmx, enabling server-side access control integration.

### Added
- **Authentication configuration** (`config::AuthnConfig`)
  - Provider types: `none`, `custom`, `oidc`
  - Configurable signin/signout endpoints
  - Session cookie name setting
  - User info endpoint for current user

- **Authorization configuration** (`config::AuthzConfig`)
  - Default access levels: `public`, `authenticated`, `denied`
  - Default fallback page for access denied
  - JWT role claim configuration
  - Strict mode option (deny if role claim missing)

- **Frontmatter auth fields**
  - `authn` - Authentication level (`public`, `authenticated`, `verified`)
  - `authz` - Required roles list
  - `fallback` - Custom fallback page for access denied

- **Auth templates**
  - `partials/signin.html` - Sign-in prompt partial
  - `partials/access-denied.html` - Access denied partial
  - `401.html` - Unauthorized error page
  - `403.html` - Forbidden error page

- `AuthnLevel.as_str()` and `Display` implementation
- 12 new unit tests for auth configuration and frontmatter

### Changed
- `HtmxConfig` now includes `authn` and `authz` configuration
- Manifest includes auth metadata from frontmatter

## Test plan
- [x] All 41 unit tests pass
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt` applied
- [ ] Manual verification of template rendering

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)