### PR TITLE
fix(sync): use docs-sync/ branch prefix and support PR updates

### DIFF
--- a/.github/actions/cross-repo-sync/action.yml
+++ b/.github/actions/cross-repo-sync/action.yml
@@ -141,10 +141,10 @@ runs:
       shell: bash
       working-directory: target
       run: |
-        # Branch naming: <sync-type>/<source-repo-name>/<short-sha>
+        # Branch naming: <sync-type>-sync/<source-repo-name>
+        # Using stable branch name (no SHA) to enable PR updates on re-runs
         SOURCE_REPO_NAME="${GITHUB_REPOSITORY##*/}"
-        SHORT_SHA="${GITHUB_SHA:0:7}"
-        BRANCH="${{ inputs.sync-type }}/${SOURCE_REPO_NAME}/${SHORT_SHA}"
+        BRANCH="${{ inputs.sync-type }}-sync/${SOURCE_REPO_NAME}"
 
         echo "::group::Creating worktree"
         git worktree add ../target-worktree -b "$BRANCH"
@@ -268,9 +268,10 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.token }}
       run: |
-        git push origin "${{ steps.branch.outputs.name }}"
+        # Use force-with-lease for stable branches (allows updating existing PRs)
+        git push --force-with-lease origin "${{ steps.branch.outputs.name }}"
 
-    - name: Create draft PR
+    - name: Create or update PR
       id: pr
       if: steps.changes.outputs.has_changes == 'true'
       shell: bash
@@ -278,23 +279,40 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.token }}
       run: |
-        # Determine PR title
-        PR_TITLE="${{ inputs.pr-title }}"
-        if [ -z "$PR_TITLE" ]; then
-          PR_TITLE="${{ inputs.sync-type }}(sync): update from ${{ github.repository }}"
+        # Check for existing open PR on this branch
+        EXISTING_PR=$(gh pr list \
+          --head "${{ steps.branch.outputs.name }}" \
+          --state open \
+          --json number \
+          --jq '.[0].number // empty' \
+          --repo "${{ inputs.target-repo }}" 2>/dev/null || true)
+
+        if [ -n "$EXISTING_PR" ]; then
+          echo "::notice::Updating existing PR #$EXISTING_PR"
+          PR_URL=$(gh pr view "$EXISTING_PR" --json url -q .url --repo "${{ inputs.target-repo }}")
+          echo "url=$PR_URL" >> $GITHUB_OUTPUT
+          echo "number=$EXISTING_PR" >> $GITHUB_OUTPUT
+          echo "created=false" >> $GITHUB_OUTPUT
+        else
+          # Determine PR title
+          PR_TITLE="${{ inputs.pr-title }}"
+          if [ -z "$PR_TITLE" ]; then
+            PR_TITLE="${{ inputs.sync-type }}(sync): update from ${{ github.repository }}"
+          fi
+
+          # Create draft PR with placeholder body
+          PR_URL=$(gh pr create \
+            --draft \
+            --title "$PR_TITLE" \
+            --body "Sync in progress... attestation pending." \
+            --repo "${{ inputs.target-repo }}")
+
+          PR_NUMBER=$(gh pr view "$PR_URL" --json number -q .number)
+
+          echo "url=$PR_URL" >> $GITHUB_OUTPUT
+          echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "created=true" >> $GITHUB_OUTPUT
         fi
-
-        # Create draft PR with placeholder body
-        PR_URL=$(gh pr create \
-          --draft \
-          --title "$PR_TITLE" \
-          --body "Sync in progress... attestation pending." \
-          --repo "${{ inputs.target-repo }}")
-
-        PR_NUMBER=$(gh pr view "$PR_URL" --json number -q .number)
-
-        echo "url=$PR_URL" >> $GITHUB_OUTPUT
-        echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
 
     # ==========================================================================
     # PHASE 3: ATTESTATION
@@ -447,7 +465,8 @@ runs:
           --add-label "$LABELS" || true
 
     - name: Mark PR ready
-      if: steps.changes.outputs.has_changes == 'true'
+      # Only mark ready if we created a new PR (not updating existing)
+      if: steps.changes.outputs.has_changes == 'true' && steps.pr.outputs.created == 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}

--- a/.github/workflows/test-cross-repo-sync.yml
+++ b/.github/workflows/test-cross-repo-sync.yml
@@ -343,15 +343,14 @@ jobs:
           SYNC_TYPE="docs"
           SOURCE_REPO="${{ github.repository }}"
           SOURCE_REPO_NAME="${SOURCE_REPO##*/}"
-          SHORT_SHA="${{ github.sha }}"
-          SHORT_SHA="${SHORT_SHA:0:7}"
 
-          BRANCH="${SYNC_TYPE}/${SOURCE_REPO_NAME}/${SHORT_SHA}"
+          # Stable branch naming (no SHA suffix for PR update support)
+          BRANCH="${SYNC_TYPE}-sync/${SOURCE_REPO_NAME}"
 
           echo "Generated branch name: $BRANCH"
 
-          # Validate format
-          if [[ ! "$BRANCH" =~ ^[a-z]+/[a-zA-Z0-9_.-]+/[a-f0-9]{7}$ ]]; then
+          # Validate format: <type>-sync/<repo-name>
+          if [[ ! "$BRANCH" =~ ^[a-z]+-sync/[a-zA-Z0-9_.-]+$ ]]; then
             echo "Invalid branch format: $BRANCH"
             exit 1
           fi


### PR DESCRIPTION
## Summary

- Fix branch naming to use `<type>-sync/<repo>` format (e.g., `docs-sync/mdbook-htmx`)
- Add support for updating existing PRs instead of creating new ones on each sync
- Close old PR #15 in aRustyDev/docs (had old branch format)

## Changes

### Fixed
- Branch naming now uses `-sync` suffix to match aRustyDev/docs validation workflow expectations

### Added
- Existing PR detection - reuses open PRs instead of creating new ones
- Force-push with lease for stable branch updates
- Skip "mark ready" step for existing PRs (already ready)

### Changed
- Removed SHA suffix from branch names for stable PR updates
- Updated test workflow regex to match new format

## Test plan

- [x] Merge this PR
- [ ] Run e2e-cross-repo-sync workflow
- [ ] Verify new PR created with `docs-sync/mdbook-htmx` branch
- [ ] Verify validation workflow triggers in docs repo
- [ ] Run workflow again to verify it updates the same PR

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)